### PR TITLE
Fix k8s iconPath

### DIFF
--- a/icon/k8s/k8s.go
+++ b/icon/k8s/k8s.go
@@ -62,10 +62,11 @@ func (f *K8sIcon) Fetch(iconPath, prefix string) error {
 		}
 		var path string
 		if matched[2] == "labeled" {
-			path = rep.Replace(filepath.Join(iconPath, prefix, matched[1], fmt.Sprintf("%s.%s", matched[3], "svg")))
+			path = rep.Replace(filepath.Join(prefix, matched[1], fmt.Sprintf("%s.%s", matched[3], "svg")))
 		} else {
-			path = rep.Replace(filepath.Join(iconPath, prefix, matched[1], fmt.Sprintf("%s-%s.%s", matched[3], matched[2], "svg")))
+			path = rep.Replace(filepath.Join(prefix, matched[1], fmt.Sprintf("%s-%s.%s", matched[3], matched[2], "svg")))
 		}
+		path = filepath.Join(iconPath, path)
 		if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 			return err
 		}


### PR DESCRIPTION
If iconPath contains underscores, these are also replaced by dashes, so I fixed it.

```sh
$ pwd
/Users/r_nakamine/ndiag

$ ndiag fetch-icons k8s
Fetching icons from https://github.com/kubernetes/community/archive/master.zip ...
Error: mkdir /Users/r-nakamine/ndiag: permission denied
mkdir /Users/r-nakamine/ndiag: permission denied

```