### PR TITLE
Fix the conditions for getting the HashiCorp icon.

### DIFF
--- a/icon/hashicorp/hashicorp.go
+++ b/icon/hashicorp/hashicorp.go
@@ -58,7 +58,7 @@ func (f *HashicorpIcon) Fetch(iconPath, prefix string) error {
 			if !strings.Contains(f.Name, ".svg") {
 				continue
 			}
-			if !strings.Contains(f.Name, "FullColor") || strings.Contains(f.Name, "Enterprise") {
+			if !strings.Contains(f.Name, "Color") || strings.Contains(f.Name, "Enterprise") {
 				continue
 			}
 


### PR DESCRIPTION
I had a problem fetching the hashcorp icon.

The file name downloaded from GoogleDrive may have been changed, and we are currently unable to retrieve the svg file.

```sh
$ ndiag fetch-icons hashicorp
Fetching icons from https://drive.google.com/uc?export=download&id=1EtZa2tnvRJoSk5kqJtuToS8mLnQudoiM ...
Fetching icons from https://drive.google.com/uc?export=download&id=1MgDnPnLnTAUQPGwDskbQns1R7KwkjDot ...
Fetching icons from https://drive.google.com/uc?export=download&id=18sAMuWBoedXWDDZwfuTzaUUmDrpezr7s ...
Fetching icons from https://drive.google.com/uc?export=download&id=1MWU8ODoxNFebk_MXlNlUWs98lqxqEqtN ...
Fetching icons from https://drive.google.com/uc?export=download&id=1cC7MFfkq3sCj_NK4sBCC8hgUPWbLxval ...
Fetching icons from https://drive.google.com/uc?export=download&id=17tlD38R-KQmAN1NnQ0RL6ROeXOEwiWRx ...
Fetching icons from https://drive.google.com/uc?export=download&id=1GA8kNh_8QYNHRP-kdMvbWH_AqVY2hDV7 ...
0 icons fetched
Done.
```

The file names currently available from Google Drive are:
```
Fetching icons from https://drive.google.com/uc?export=download&id=1EtZa2tnvRJoSk5kqJtuToS8mLnQudoiM ...
1 - Vagrant/1 - Primary - Horizontal/RGB/SVG/Vagrant_PrimaryLogo_NonAtt_MonoTonal_RGB.svg
1 - Vagrant/1 - Primary - Horizontal/RGB/SVG/Vagrant_PrimaryLogo_NonAtt_Black_RGB.svg
1 - Vagrant/1 - Primary - Horizontal/RGB/SVG/Vagrant_PrimaryLogo_NonAtt_White_RGB.svg
1 - Vagrant/1 - Primary - Horizontal/RGB/SVG/Vagrant_PrimaryLogo_Color_RGB.svg
1 - Vagrant/1 - Primary - Horizontal/RGB/SVG/Vagrant_PrimaryLogo_MonoTonal_RGB.svg
1 - Vagrant/1 - Primary - Horizontal/RGB/SVG/Vagrant_PrimaryLogo_ColorWhite_RGB.svg
1 - Vagrant/1 - Primary - Horizontal/RGB/SVG/Vagrant_PrimaryLogo_NonAtt_ColorWhite_RGB.svg
1 - Vagrant/1 - Primary - Horizontal/RGB/SVG/Vagrant_PrimaryLogo_NonAtt_Color_RGB.svg
1 - Vagrant/1 - Primary - Horizontal/RGB/SVG/Vagrant_PrimaryLogo_White_RGB.svg
1 - Vagrant/1 - Primary - Horizontal/RGB/SVG/Vagrant_PrimaryLogo_Black_RGB.svg
1 - Vagrant/2 - Secondary - Vertical/RGB/SVG/Vagrant_VerticalLogo_White_RGB.svg
1 - Vagrant/2 - Secondary - Vertical/RGB/SVG/Vagrant_VerticalLogo_Black_RGB.svg
1 - Vagrant/2 - Secondary - Vertical/RGB/SVG/Vagrant_VerticalLogo_ColorWhite_RGB.svg
1 - Vagrant/2 - Secondary - Vertical/RGB/SVG/Vagrant_VerticalLogo_Color_RGB.svg
1 - Vagrant/2 - Secondary - Vertical/RGB/SVG/Vagrant_VerticalLogo_MonoTonal_RGB.svg
Fetching icons from https://drive.google.com/uc?export=download&id=1MgDnPnLnTAUQPGwDskbQns1R7KwkjDot ...
2 - Packer/1 - Primary - Horizontal/RGB/SVG/Packer_PrimaryLogo_White_RGB.svg
2 - Packer/1 - Primary - Horizontal/RGB/SVG/Packer_PrimaryLogo_NonAtt_Black_RGB.svg
2 - Packer/1 - Primary - Horizontal/RGB/SVG/Packer_PrimaryLogo_NoAtt_White_RGB.svg
2 - Packer/1 - Primary - Horizontal/RGB/SVG/Packer_PrimaryLogo_Black_RGB.svg
2 - Packer/1 - Primary - Horizontal/RGB/SVG/Packer_PrimaryLogo_NonAtt_ColorWhite_RGB.svg
2 - Packer/1 - Primary - Horizontal/RGB/SVG/Packer_PrimaryLogo_NonAtt_Color_RGB.svg
2 - Packer/1 - Primary - Horizontal/RGB/SVG/Packer_PrimaryLogo_Color_RGB.svg
2 - Packer/1 - Primary - Horizontal/RGB/SVG/Packer_PrimaryLogo_ColorWhite_RGB.svg
2 - Packer/2 - Secondary - Vertical/RGB/SVG/Packer_VerticalLogo_ColorWhite_RGB.svg
2 - Packer/2 - Secondary - Vertical/RGB/SVG/Packer_VerticalLogo_Color_RGB.svg
2 - Packer/2 - Secondary - Vertical/RGB/SVG/Packer_VerticalLogo_White_RGB.svg
2 - Packer/2 - Secondary - Vertical/RGB/SVG/Packer_VerticalLogo_Black_RGB.svg

--- snip ---

```

You can download it by changing the acquisition conditions ( https://github.com/k1LoW/ndiag/commit/9e1da4e0e0cafa314858b4f597fc717d761f382e )